### PR TITLE
skip ci:release - automatic pull request updating versioning files

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,6 +35,7 @@ snapshot:
 archives:
   - format: binary
 release:
+  draft: true
   extra_files:
     - glob: ./deployments/cosign.pub
 signs:


### PR DESCRIPTION
This is a automatic pull request that contains changes to files that need to be updated with the new release version. Where the commit 387173d9b76db248cc2cda52754cddc000b1dc74 was cherry picked from the release branch, which already contains all the necessary changes.